### PR TITLE
Changed location of the OCaml mascot, it didn't seem to be visible in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Elements of Functional Computing 🐪
+Elements of Functional Computing
 ==================================
-
+🐪
 
 Getting Set Up:
 ---------------


### PR DESCRIPTION
… the header.
